### PR TITLE
Fix #72731 win32 large-address-aware

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,7 @@ else (APPLE)
       # -mno-ms-bitfields see #22048
       set(CMAKE_CXX_FLAGS_DEBUG   "-std=gnu++0x -mno-ms-bitfields -g")
       set(CMAKE_CXX_FLAGS_RELEASE "-std=gnu++0x -mno-ms-bitfields -O2 -DNDEBUG -DQT_NO_DEBUG")
+      set(CMAKE_EXE_LINKER_FLAGS "-Wl,--large-address-aware")
    else (MINGW)
       set(CMAKE_CXX_FLAGS_DEBUG   "-std=c++11 -fPIC -fPIE -g")
       set(CMAKE_CXX_FLAGS_RELEASE "-std=c++11 -fPIC -O2 -DNDEBUG -DQT_NO_DEBUG")


### PR DESCRIPTION
This allows 32-bit win builds to access up to 4GB memory when run in 64-bit windows.

This fixes a crash that occurred when loading multiple large soundfonts in windows when exceed the 2GB memory limit of regular 32-bit windows applications linked without --large-address-aware.  I'm able to build release both via command line makefile and in QT Creator, and tested them both to ensure now I'm able to load two very large zerberus .sfz soundfonts without crashing mscore.
